### PR TITLE
fix issue of gettid build error in openeuler

### DIFF
--- a/src/tools/lhsmtool_cmd.c
+++ b/src/tools/lhsmtool_cmd.c
@@ -167,7 +167,7 @@ static inline double ct_now(void)
 	return tv.tv_sec + 0.000001 * tv.tv_usec;
 }
 
-static inline pid_t gettid(void)
+static inline pid_t rbh_gettid(void)
 {
 	return syscall(SYS_gettid);
 }
@@ -175,12 +175,12 @@ static inline pid_t gettid(void)
 #define LOG_ERROR(_rc, _format, ...)					\
 	llapi_error(LLAPI_MSG_ERROR, _rc,				\
 		    "%f %s[%d]: "_format,				\
-		    ct_now(), cmd_name, gettid(), ## __VA_ARGS__)
+		    ct_now(), cmd_name, rbh_gettid(), ## __VA_ARGS__)
 
 #define LOG_DEBUG(_format, ...)						\
 	llapi_error(LLAPI_MSG_DEBUG | LLAPI_MSG_NO_ERRNO, 0,		\
 		    "%f %s[%d]: "_format,				\
-		    ct_now(), cmd_name, gettid(), ## __VA_ARGS__)
+		    ct_now(), cmd_name, rbh_gettid(), ## __VA_ARGS__)
 
 static void usage(const char *name, int rc)
 {


### PR DESCRIPTION
[root@host]# lsb_release -a
LSB Version:    n/a
Distributor ID: openEuler
Description:    openEuler release 22.03 (LTS-SP3)
Release:        22.03
Codename:       LTS-SP3

[root@host]# uname -a
Linux host 5.10.0-202.0.0.115.oe2203sp3.aarch64 #1 SMP Wed Jun 5 17:54:17 CST 2024 aarch64 aarch64 aarch64 GNU/Linux

build error

lhsmtool_cmd.c:170:21: error: static declaration of ‘gettid’ follows non-static declaration
  170 | static inline pid_t gettid(void)
      |                     ^~~~~~
In file included from /usr/include/unistd.h:1204,
                 from lhsmtool_cmd.c:64:
/usr/include/bits/unistd_ext.h:34:16: note: previous declaration of ‘gettid’ was here
   34 | extern __pid_t gettid (void) __THROW;
